### PR TITLE
[ refactor ] safe resource management

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ replace in performance critical code than mere mutable references.
 How does Idris implement computations with side effects such as
 reading files, sending messages over the network, or showing an
 animation on screen? All this can be done in a referentially
-transparent way, by using a simple trick. But first, what does
+transparent way by using a simple trick. But first, what does
 it even mean for a function to be "referentially transparent"?
 
 ### (Breaking) Referential Transparency
 
 An expression is said to be "referentially transparent", if it
-can be replaced with another expression denoting the same value, without
+can be replaced with another expression denoting the same value without
 changing a program's behavior. Or, more simply put, a referentially
 transparent expression can always be replaced with the value it
 evaluates to without changing a program's behavior.
@@ -143,7 +143,8 @@ the same mutable variable. This is
 the opposite of referential transparency, and if the compiler
 decided to convert `refNat1` to the form of `refNat2` as an
 optimization, we would start seeing different behavior probably
-depending on the optimization level set at the compiler.
+depending on the optimization level set at the compiler. Good
+luck debugging this kind of wickedness!
 
 Note however, that `refNat3` evaluates to the same value as
 `refNat1`, and that's actually what this library is all about:
@@ -178,7 +179,7 @@ PrimIO.PrimIO : Type -> Type
 PrimIO a = (1 _ : %World) -> IORes a
 ```
 
-Now, what is that supposed to mean?
+Let's dissect this a bit.
 First, this value of type `%World` represents the current state
 of the world: You computer's hard-drive, mouse position, the
 temperature outside, number of people currently having a drink,
@@ -186,8 +187,8 @@ everything: The whole universe. "How can that fit
 into a single variable?", I hear you say. Well, it doesn't, nor
 does it have to. `%World` is just a semantic token: It *represents*
 the state of the world. At runtime, it is just a constant like `0`,
-`null`, or `undefined` that's being passed around. It is only of
-importance at compile-time.
+`null`, or `undefined` that's being passed around and never inspected.
+It is only of importance at compile-time.
 
 It is important to note that `%World` comes
 at quantity one, so a function of type `IO a` must consume
@@ -228,10 +229,10 @@ can be safely built on top of this. But there are some caveats:
   is, we can't break out of `IO`. We always have a world state of
   quantity one, so we must consume it, but as soon as it has been consumed,
   we get another one, again of quantity one.
-  So, there cannot be a safe function of type `IO a -> a` that extracts
+  Therefore, there cannot be a safe function of type `IO a -> a` that extracts
   a result from `IO`. This would require us to semantically destroy the
   world! Actually, there is `unsafePerformIO`, which has exactly this
-  type, and it is called "unsafe" for a reason.
+  type. It is called "unsafe" for a reason.
 
 We can look at how all of this works with an example:
 
@@ -250,7 +251,7 @@ printTime = primIO printTimePrim
 ```
 
 In the code above, we converted all `IO` actions to `PrimIO` functions
-by using utility `toPrim`. This is allowed and a safe thing to do! In
+by using utility `toPrim`. This is allowed and a safe thing to do. In
 `PrimIO`, we run computations with side effects by passing around
 the `%World` token explicitly (starting with `w1`). Every effectful
 computation will consume the current world state, and - since it has
@@ -365,7 +366,7 @@ this function type and wrap it up in a new data constructor.
 That's the `State` monad. And just like `IO a` is a monadic wrapper
 for `PrimIO a`, `State s a` is a wrapper for `s -> (s,a)`. Note also,
 how the code with its `let`-bindings and pattern matches
-on pairs, resembles the `PrimIO` code we wrote further above. That's no
+on pairs resembles the `PrimIO` code we wrote further above. That's no
 coincidence: Both describe pure, stateful computations after all.
 
 Now, I'm not going to look at the state monad in detail, but I'll
@@ -404,7 +405,7 @@ Traversable Tree where
     assert_total (Node <$> traverse (traverse g) xs)
 ```
 
-And now it's a simple matter to traverse our data structures
+And now it's a simple matter of traversing our data structures
 with `pairWithIndex` and run the whole thing starting from
 index zero:
 
@@ -416,8 +417,15 @@ zipWithIndexListState : List a -> List (Nat,a)
 zipWithIndexListState = evalState 0 . traverse pairWithIndex
 ```
 
+Or, more general (this makes the two functions above redundant):
+
+```idris
+zipWithIndexState : Traversable f => f a -> f (Nat,a)
+zipWithIndexState = evalState 0 . traverse pairWithIndex
+```
+
 Now that's more to our liking: Nice and declarative. And indeed,
-the state monad together with traverse makes for a nice user
+the state monad together with traverse makes for a nice programming
 experience.
 
 ### Performance Overhead
@@ -429,9 +437,9 @@ with `State` than with explicit recursion. In addition,
 `traverse` cannot be made tail recursive unless it is
 manually specialized for `State`, in which case we might
 just as well ditch the `State` monad altogether. And
-stack safety is important on all backends with a limted
+stack safety is important on all backends with a limited
 stack size such as the JavaScript backends. There,
-`zipWithIndexListState` will overflow the call stack
+`zipWithIndexState` will overflow the call stack
 for lists holding more than a couple of thousand elements.
 
 So, with the above two options it seems like we either get
@@ -449,8 +457,8 @@ Haskell's [Lazy Functional State Threads](https://www.microsoft.com/en-us/resear
 which offers safe encapsulation of mutable state
 in pure, referentially transparent computations.
 
-The key idea is, that the `ST` monad is parameterized
-by a phantom type (a type parameter with no runtime
+The key idea to parameterize the `ST` monad
+over a phantom type `s` (a type parameter with no runtime
 relevance): `ST s a`. Mutable arrays and references are
 then parameterized by the same phantom type `s`, so
 that a mutable reference invariably belongs to a specific,
@@ -535,12 +543,15 @@ And yet, `ST` is still considerably slower than explicit recursion.
 In addition, `traverse` is still not stack-safe, so it can't be used
 with large lists on the JavaScript and similar backends.
 
-## Enter: `Ref1`
+In addition, it is currently not possible to get safe allocation-release
+cycles (such as allocating and releasing the memory for a raw C-pointer)
+with the `ST` monad. It is therefore quite limited in its current state.
+
+## Enter: `T1`
 
 I am now going to show how the limitations demonstrated above
-can be overcome by using mutable references tagged in a similar way
-as `STRef` but bound to a linear token with the same tag that
-guarantees the computation stays in the same computational thread.
+can be overcome by using a linear token to which all kinds of
+(mutable!) resources can be bound and use locally in a computation.
 
 This is going to replace `ST s`, and comes without the overhead from
 using a monad to sequence computations. The code therefore closely
@@ -548,145 +559,145 @@ resembles the raw let bindings of `PrimIO`. Here's the example for
 zipping the values in a list with their index:
 
 ```idris
--- pairWithIndex1 : Ref1 () s Nat => a -> F1 s (Nat, a)
--- pairWithIndex1 v t1 =
---   let n # t2 := read1 t1
---    in (n,v) # write1 (S n) t2
---
--- zipWithIndex1 : Traversable1 f => f a -> f (Nat,a)
--- zipWithIndex1 as = withRef1 0 (traverse1 pairWithIndex1 as)
+pairWithIndex1 : (r : Ref1 Nat) -> a -> (1 t : T1 [r]) -> R1 [r] (Nat,a)
+pairWithIndex1 r v t1 =
+  let n # t2 := read1 r t1
+   in (n,v) # write1 r (S n) t2
+
+zipWithIndex1 : Traversable1 f => f a -> f (Nat,a)
+zipWithIndex1 as = withRef1 0 $ \r => traverse1 (pairWithIndex1 r) as
 ```
 
-There are several things to note in the code above. First, `Ref1 () s Nat`
-is a mutable reference holding a natural number. It is parameterized over
-the state thread `s` just like `STRef` in the `ST` monad. However, `Ref1`
-comes with another parameter, set to unit (`()`) in the example above.
+There are several things to note in the code above. First, `Ref1 Nat`
+is a mutable reference holding a natural number. It is bound to a
+linear token `t`, parameterized with a list of bound resources.
+We cannot use a `Ref1 a` without the token it was bound to, and we cannot
+bind it to a different token without using `unsafeBind`, which is again
+called "unsafe" for a reason. Function `withRef1` allocates and releases
+a mutable reference for us, and we are free to use it in our anonymous
+function (after the dollar sign).
 
-The idea is to use mutable references as auto-implicit arguments. This
-allows us to conveniently put them in `parameters` blocks thus
-decluttering our function signatures. But then it can be tedious to
-distinguish between mutable references if several of them are
-currently in use. For these occasions, we can tag them with
-something more specific than unit and use functions such as
-`read1At` and `write1At` together with a reference's tag to specify
-exactly, which tag we mean.
-
-Second, the result type of `pairWithIndex1` is `F1 s (Nat,a)`, which
-is function alias just like `PrimIO a`:
+The type `(1 t : T1 rs) -> R1 rs a` is so common in this kind of computation,
+that we get a short alias called `F1 rs a` for it:
 
 ```repl
 README> :printdef F1
-0 Data.Linear.Token.F1 : Type -> Type -> Type
-F1 s a = T1 s -@ R1 s a
+0 Data.Linear.Token.F1 : Resources -> Type -> Type
+F1 rs a = T1 rs -@ R1 rs a
 ```
 
-This shows us two more ingredients: `T1 s` and `R1 s a`.
-`T1 s` is a linear token comparable to `%World` because
-it must be used exactly once to avoid calling a function
-with mutable state with the same arguments twice. Unlike `%World`,
-we are allowed to create (see below) and destroy (`discard`) such
-tokens at will, thus using them to write pure functions that use
-mutable state under the hood.
-
 `R1 s a` is a linear result just like `IORes a`, that wraps a result
-of type `a` with a new linear token of type `T1 s`. All of this
+of type `a` with a new linear token of type `T1 rs`. All of this
 allows us to write safe, single-threaded and stateful computations
 in a way that strongly resembles programming in `PrimIO`.
 
+But how does this prevent us from using functions such as `read1` or
+`write1` with a mutable reference together with the wrong linear token?
+When we look at the type of `read1`, we see that there is a link between
+the mutable reference `r` and the list of resources `rs`:
+
+```repl
+README> :t read1
+Data.Linear.Ref1.read1 : (r : Ref1 a) -> {auto 0 _ : Res r rs} -> F1 rs a
+```
+
+A value of type `Res r rs` is a proof that `r` is one of the elements of `rs`,
+that is, `r` is one of the resources bound to the linear token! Since a
+mutable reference will always be bound to the linear token it was created with
+(see function `ref1`), it is not possible to use a mutable reference with
+the wrong token. It therefore becomes completely useless outside of the
+current linear computation.
+
 ### A simple Word Count Example
 
-In order to demonstrate the use of tagged references, we are
+In order to demonstrate how all of this works together, we are
 going to write a simple word count program that counts characters,
 words, and lines of text in a single traversal of a list of
 characters. I'm not claiming that this is the most elegant or
-declarative way to do this. It just shows how to use tags.
+declarative way to do this. It just shows how to create, use, and
+release mutable references.
 
 When counting characters, words, and lines, we need three
 mutable references for counting each entity. In addition, we
 need a boolean flag to keep track of word beginnings and ends.
 
-We can define an enum type for these four references:
-
-```idris
--- data Tag = Chars | Words | Lines | InWord
-```
-
 With these, we can write a couple of utilities and then the
 main character processing routine. Their result type is
-always `F1' s`, which is an alias for `(1 t : T1 s) -> T1 s`.
-So, this is a function that potentially mutates some state but
-does not produce any other result of interest.
+always `F1' rs`, which is an alias for `(1 t : T1 rs) -> T1 rs`.
+So, these are functions that potentially mutate some state but
+do not produce any other results of interest.
 
 ```idris
--- inc : (0 tag : _) -> Ref1 tag s Nat => F1' s
--- inc tag = mod1At tag S
---
--- endWord : Ref1 InWord s Bool => Ref1 Words s Nat => F1' s
--- endWord t = write1At InWord False (whenRef1 InWord (inc Words) t)
---
--- parameters {auto cs : Ref1 Chars s Nat}
---            {auto ws : Ref1 Words s Nat}
---            {auto ls : Ref1 Lines s Nat}
---            {auto iw : Ref1 InWord s Bool}
---
---   processChar : Char -> F1' s
---   processChar c t =
---     case isAlpha c of
---       True  => inc Chars (write1At InWord True t)
---       False => inc Chars $ endWord $ when1 (c == '\n') (inc Lines) t
+inc : (r : Ref1 Nat) -> (0 p : Res r rs) => F1' rs
+inc r = mod1 r S
+
+endWord : (b : Ref1 Bool) -> (w : Ref1 Nat) -> F1' [c,w,l,b]
+endWord b w t = write1 b False (whenRef1 b (inc w) t)
+
+processChar : (c,w,l : Ref1 Nat) -> (b : Ref1 Bool) -> Char -> F1' [c,w,l,b]
+processChar c w l b x t =
+  case isAlpha x of
+    True  => inc c (write1 b True t)
+    False => inc c $ endWord b w $ when1 (x == '\n') (inc l) t
 ```
 
 The actual `wordCount` function has to setup all mutable variables,
-traverse the sequence of characters, and read the final values from
-the mutable refs.
+traverse the sequence of characters, read the final values from
+the mutable refs, and cleanup everything at the end.
 
 ```idris
--- record WordCount where
---   constructor WC
---   chars : Nat
---   words : Nat
---   lines : Nat
---
--- %runElab derive "WordCount" [Show,Eq]
---
--- wordCount1 : String -> WordCount
--- wordCount1 "" = WC 0 0 0
--- wordCount1 s  =
---   run1 $ \t1 =>
---     let cs # t2  := ref1At Chars Z t1
---         ws # t3  := ref1At Words Z t2
---         ls # t4  := ref1At Lines (S Z) t3
---         iw # t5  := ref1At InWord False t4
---         t6       := traverse1_ processChar (unpack s) t5
---         t7       := endWord t6
---         x  # t8  := read1At Chars t7
---         y  # t9  := read1At Words t8
---         z  # t10 := read1At Lines t9
---      in WC x y z # t10
+record WordCount where
+  constructor WC
+  chars : Nat
+  words : Nat
+  lines : Nat
+
+%runElab derive "WordCount" [Show,Eq]
+
+wordCount : String -> WordCount
+wordCount "" = WC 0 0 0
+wordCount s  =
+  run1 $ \t =>
+    let A b t  := ref1 False t
+        A l t  := ref1 (S Z) t
+        A w t  := ref1 Z t
+        A c t  := ref1 Z t
+        t      := traverse1_ (processChar c w l b) (unpack s) t
+        t      := endWord b w t
+        x  # t := readAndRelease c t
+        y  # t := readAndRelease w t
+        z  # t := readAndRelease l t
+     in WC x y z # release b t
 ```
 
-This last step is quite verbose. Since this is not a performance-critical
-part of our code (the machinery has to be set up only once in order
-to process potentially huge amounts of text), we can opt for some
-syntactic sugar (from module `Data.Linear.Token.Syntax`):
+This last step is quite verbose. This is to be expected: Just like in
+imperative languages, we have to introduce mutable variables before
+we can use them. It is also a bit tedious that we have to manually
+thread our linear token through the whole computation. There is
+some `do` notation available from `Data.Linear.Token.Syntax`, but it
+is currently only implemented for those cases where the list of
+resources stays constant. This might change in future versions of
+this library.
+
+However, we gain a lot from all of this: Fast, mutable state localised
+to pure computations together with safe resource management. To understand
+this, look at the type of `run1`:
+
+```repl
+README> :t run1
+Data.Linear.Token.run1 : F1 [] a -> a
+```
+
+We extract a value of type `a` from a linear computation that
+*starts and ends* with zero allocated resources: We can't forget to
+release all resources that we set up along the way!
+
+Finally, we can test our mini application:
 
 ```idris
--- wordCount : String -> WordCount
--- wordCount "" = WC 0 0 0
--- wordCount s  =
---   run1 $ Token.Syntax.do
---     cs <- ref1At Chars Z
---     ws <- ref1At Words Z
---     ls <- ref1At Lines (S Z)
---     iw <- ref1At InWord False
---     traverse1_ processChar (unpack s)
---     endWord
---     [| WC (read1At Chars) (read1At Words) (read1At Lines) |]
---
--- main : IO ()
--- main = do
---   printLn (wordCount1 "hello world!\nhow are you?")
---   printLn (wordCount "hello world!\nhow are you?")
+covering
+main : IO ()
+main = printLn (wordCount "hello world!\nhow are you?")
 ```
 
 That's quite a bit more concise. We used qualified `do` notation, because

--- a/src/Data/Linear/Ref1.idr
+++ b/src/Data/Linear/Ref1.idr
@@ -10,142 +10,78 @@ import public Data.Linear.Token
 
 -- Implemented externally
 -- e.g., in Scheme, passed around as a box
-data Mut : Type -> Type where [external]
+data Mut : Type where [external]
 
-export %foreign "scheme:(lambda (u x) (box x))"
-                "javascript:lambda:(u,x) => ({value : x})"
-prim__newRef   : a -> Mut a
+export %foreign "scheme:(lambda (x) (box x))"
+                "javascript:lambda:(x) => ({value : x})"
+prim__newRef   : AnyPtr -> Mut
 
-export %foreign "scheme:(lambda (u x) (unbox x))"
-                "javascript:lambda:(u,x) => x.value"
-prim__readRef  : Mut a -> a
+export %foreign "scheme:(lambda (x) (unbox x))"
+                "javascript:lambda:(x) => x.value"
+prim__readRef  : Mut -> AnyPtr
 
-export %foreign "scheme:(lambda (s u x v t) (begin (set-box! x v) t))"
-                "javascript:lambda:(s,u,x,v,t) => {x.value = v; return t;}"
-prim__writeRef : Mut a -> (val : a) -> (1 x : T1 s) -> T1 s
+export %foreign "scheme:(lambda (x v t) (begin (set-box! x v) t))"
+                "javascript:lambda:(x,v,t) => {x.value = v; return t;}"
+prim__writeRef : Mut -> (val : AnyPtr) -> (1 x : AnyPtr) -> AnyPtr
 
 --------------------------------------------------------------------------------
 -- Ref1: A linearily mutable reference
 --------------------------------------------------------------------------------
 
-||| A linear mutable reference tagged with resolution tag `tag`,
-||| bound to linear state thread `s`, and holding values of type `a`.
-|||
-||| About the type parameters:
-|||
-|||   `tag`: The idea is to use `Ref1 tag s a` as an auto-implicit function
-|||          argument, so that it can be conveniently used in `parameters`
-|||          blocks. Since we might require more than one mutable reference,
-|||          we need to be able to distinguish between them. This is what `tag` is
-|||          for: The genral functions for creating, reading, and writing
-|||          mutable references all take an erased `tag` argument to specify the
-|||          reference we want to use (see `ref1At`, `read1At`, `write1At`,
-|||          and other utility functions ending on "At").
-|||
-|||          If you only need one mutable reference in your function, consider
-|||          using the utilities not ending on "At", which are specialized
-|||          for working with references tagged with unit (`()`).
-|||
-|||   `s`:   Tag of the state thread the mutable reference is used in.
-|||          In order to make sure a linear reference does not leak into
-|||          the outer world, it is tagged with the state thread of the
-|||          linear token it was created with. Thus, a mutable reference is
-|||          invariably bound to its corresponding token. A mutable reference
-|||          without its linear token is therefore utterly useless,
-|||          because we are never free in choosing the value of `s`: It *must* be
-|||          universally quantified, otherwise the linear computation cannot be
-|||          run (see `Linear.Token.run1`).
-|||
-|||   `a`    Just the type of values this reference holds.
+||| A linear mutable reference
 export
-data Ref1 : (tag : k) -> (s,a : Type) -> Type where
-  [search tag s]
-  R1 : (mut : Mut a) -> Ref1 tag s a
+data Ref1 : (a : Type) -> Type where
+  R1 : (mut : Mut) -> Ref1 a
 
 --------------------------------------------------------------------------------
--- Tagged utilities
+-- utilities
 --------------------------------------------------------------------------------
 
 ||| Creates a new mutable reference tagged with `tag` and holding
 ||| initial value `v`.
 export %noinline
-ref1At : (0 tag : _) -> (v : a) -> F1 s (Ref1 tag s a)
-ref1At tag v t = R1 (prim__newRef v) # t
+ref1 : (v : a) -> (1 t : T1 rs) -> A1 rs (Ref1 a)
+ref1 v t = A (R1 $ prim__newRef $ believe_me v) (bind t)
 
 ||| Reads the current value at a mutable reference tagged with `tag`.
 export %noinline
-read1At : (0 tag : _) -> Ref1 tag s a => F1 s a
-read1At _ @{R1 m} t = prim__readRef m # t
+read1 : (r : Ref1 a) -> (0 p : Res r rs) => F1 rs a
+read1 (R1 m) t = believe_me (prim__readRef m) # t
 
 ||| Updates the mutable reference tagged with `tag`.
 export
-write1At : (0 tag : _) -> Ref1 tag s a => (val : a) -> F1' s
-write1At _ @{R1 m} val t = prim__writeRef m val t
+write1 : (r : Ref1 a) -> (0 p : Res r rs) => (val : a) -> F1' rs
+write1 (R1 m) val = ffi (prim__writeRef m (believe_me val))
 
 ||| Modifies the value stored in mutable reference tagged with `tag`.
 export
-mod1At : (0 tag : _) -> Ref1 tag s a => (f : a -> a) -> F1' s
-mod1At tag f t =
-  let v # t2 := read1At tag t
-   in write1At tag (f v) t2
+mod1 : (r : Ref1 a) -> (0 p : Res r rs) => (f : a -> a) -> F1' rs
+mod1 r f t = let v # t2 := read1 r t in write1 r (f v) t2
 
 ||| Modifies the value stored in mutable reference tagged with `tag`
 ||| and returns the updated value.
 export
-modAndRead1At : (0 tag : _) -> Ref1 tag s a => (f : a -> a) -> F1 s a
-modAndRead1At tag f t =
-  let t2 := mod1At tag f t
-   in read1At tag t2
+modAndRead1 : (r : Ref1 a) -> (0 p : Res r rs) => (f : a -> a) -> F1 rs a
+modAndRead1 r f t = read1 r (mod1 r f t)
 
 ||| Modifies the value stored in mutable reference tagged with `tag`
 ||| and returns the previous value.
 export
-readAndMod1At : (0 tag : _) -> Ref1 tag s a => (f : a -> a) -> F1 s a
-readAndMod1At tag f t =
-  let v # t1 := read1At tag t
-   in v # write1At tag (f v) t1
+readAndMod1 : (r : Ref1 a) -> (0 p : Res r rs) => (f : a -> a) -> F1 rs a
+readAndMod1 r f t = let v # t1 := read1 r t in v # write1 r (f v) t1
 
 ||| Runs the given stateful computation only when given boolean flag
 ||| is currently at `True`
 export
-whenRef1 : (0 tag : _) -> Ref1 tag s Bool => Lazy (F1' s) -> F1' s
-whenRef1 tag f t =
-  let b # t1 := read1At tag t
-   in when1 b f t1
+whenRef1 : (r : Ref1 Bool) -> (0 p : Res r rs) => Lazy (F1' rs) -> F1' rs
+whenRef1 r f t = let b # t1 := read1 r t in when1 b f t1
 
---------------------------------------------------------------------------------
--- Default utilities
---------------------------------------------------------------------------------
-
-||| `ref1At` specialized to `()`.
-export %inline
-ref1 : (v : a) -> F1 s (Ref1 () s a)
-ref1 = ref1At ()
-
-||| `read1At` specialized to `()`.
-export %inline
-read1 : Ref1 () s a => F1 s a
-read1 = read1At ()
-
-||| `write1At` specialized to `()`.
-export %inline
-write1 : Ref1 () s a => a -> F1' s
-write1 = write1At ()
-
-||| `mod1At` specialized to `()`.
-export %inline
-mod1 : Ref1 () s a => (f : a -> a) -> F1' s
-mod1 = mod1At ()
-
-||| `modAndRead1At` specialized to `()`.
-export
-modAndRead1 : Ref1 () s a => (f : a -> a) -> F1 s a
-modAndRead1 = modAndRead1At ()
-
-||| `readAndMod1At` specialized to `()`.
-export
-readAndMod1 : Ref1 () s a => (f : a -> a) -> F1 s a
-readAndMod1 = readAndMod1At ()
+||| Releases a mutable reference.
+|||
+||| It will no longer be accessible through the given linear token.
+export %noinline
+release : (r : Ref1 a) -> (0 p : Res r rs) => (1 t : T1 rs) -> T1 (Drop rs p)
+release r t = unsafeRelease p t
 
 --------------------------------------------------------------------------------
 -- Allocating mutable references
@@ -155,9 +91,13 @@ readAndMod1 = readAndMod1At ()
 ||| an auto-implicit argument.
 public export
 0 WithRef1 : (a,b : Type) -> Type
-WithRef1 a b = forall s . Ref1 () s a => F1 s b
+WithRef1 a b = (r : Ref1 a) -> F1 [r] b
 
 ||| Runs a function requiring a linear mutable reference.
 export
 withRef1 : a -> WithRef1 a b -> b
-withRef1 v f = run1 $ \t => let ref # t2 := ref1 v t in f @{ref} t2
+withRef1 v f =
+  run1 $ \t =>
+    let A r t2 := ref1 v t
+        v # t3 := f r t2
+     in v # release r t3

--- a/src/Data/Linear/Ref1.idr
+++ b/src/Data/Linear/Ref1.idr
@@ -41,7 +41,7 @@ data Ref1 : (a : Type) -> Type where
 ||| initial value `v`.
 export %noinline
 ref1 : (v : a) -> (1 t : T1 rs) -> A1 rs (Ref1 a)
-ref1 v t = A (R1 $ prim__newRef $ believe_me v) (bind t)
+ref1 v t = A (R1 $ prim__newRef $ believe_me v) (unsafeBind t)
 
 ||| Reads the current value at a mutable reference tagged with `tag`.
 export %noinline
@@ -82,6 +82,17 @@ whenRef1 r f t = let b # t1 := read1 r t in when1 b f t1
 export %noinline
 release : (r : Ref1 a) -> (0 p : Res r rs) => (1 t : T1 rs) -> T1 (Drop rs p)
 release r t = unsafeRelease p t
+
+||| Read and releases a mutable reference.
+|||
+||| It will no longer be accessible through the given linear token.
+export %inline
+readAndRelease :
+     (r : Ref1 a)
+  -> {auto 0 p : Res r rs}
+  -> (1 t : T1 rs)
+  -> R1 (Drop rs p) a
+readAndRelease r t = let v # t2 := read1 r t in v # release r t2
 
 --------------------------------------------------------------------------------
 -- Allocating mutable references

--- a/src/Data/Linear/Token.idr
+++ b/src/Data/Linear/Token.idr
@@ -40,11 +40,19 @@ data T1 : (rs : Resources) -> Type where
 
 ||| Bind a new resource to the current linear tag.
 |||
-||| This is for library authors to use when writing FFI bindings.
+||| This is for library authors when writing FFI bindings.
+||| Do not use it unless you know what you are doing! Never use this to
+||| bind an existing resource to a different linear token!
 export %inline
-bind : (1 t : T1 rs) -> T1 (r::rs)
-bind (T p) = T p
+unsafeBind : (1 t : T1 rs) -> T1 (r::rs)
+unsafeBind (T p) = T p
 
+||| Release a resource from the token it was bound to.
+|||
+||| This is for library authors when writing FFI bindings.
+||| Do not use it unless you know what you are doing! Never use this to
+||| release a resource without actually doing the releasing too (such as
+||| freeing the memory allocated for it)!
 export %inline
 unsafeRelease : (0 p : Res r rs) -> (1 t : T1 rs) -> T1 (Drop rs p)
 unsafeRelease _ (T t) = T t

--- a/src/Data/Linear/Token.idr
+++ b/src/Data/Linear/Token.idr
@@ -4,12 +4,20 @@ import public Data.Linear
 
 %default total
 
-||| `Ur` is an abbreviation for "unrestricted", meaning the wrapped value
-||| can be used an arbitrary number of times, even if the `Ur` itself is used
-||| in a linear context.
 public export
-0 Ur : Type -> Type
-Ur = (!*)
+data Resources : Type where
+  Nil  : Resources
+  (::) : {0 t : Type} -> (v : t) -> Resources -> Resources
+
+public export
+data Res : (r : t) -> Resources -> Type where
+  RH : Res r (r::rs)
+  RT : Res r rs -> Res r (s::rs)
+
+public export
+0 Drop : (rs : Resources) -> Res r rs -> Resources
+Drop (r :: rs) RH     = rs
+Drop (s :: rs) (RT x) = s :: Drop rs x
 
 ||| A linear token used in computations with mutable linear state.
 |||
@@ -25,46 +33,60 @@ Ur = (!*)
 ||| without the (significant) performance overhead of monadic code in
 ||| Idris.
 export
-data T1 : (s : Type) -> Type where [external]
+data T1 : (rs : Resources) -> Type where
+  T : AnyPtr -> T1 rs
 
 %name T1 t,t1,t2,t3
 
-%inline token : T1 s
-token = believe_me (the Bits8 0)
+||| Bind a new resource to the current linear tag.
+|||
+||| This is for library authors to use when writing FFI bindings.
+export %inline
+bind : (1 t : T1 rs) -> T1 (r::rs)
+bind (T p) = T p
 
-drop : a -> T1 s -> a
-drop v _ = v
-
-||| Drop a linear token. All associated mutable references and arrays
-||| will no longer be accessible.
-export %noinline
-discard : (1 t : T1 s) -> (v : a) -> a
-discard t x = assert_linear (drop x) t
+export %inline
+unsafeRelease : (0 p : Res r rs) -> (1 t : T1 rs) -> T1 (Drop rs p)
+unsafeRelease _ (T t) = T t
 
 ||| The result of a stateful linear computation.
 |||
 ||| It pairs the result value with a new linear token.
 public export
-data R1 : (s : Type) -> (a : Type) ->  Type where
-  (#) : (v : a) -> (1 tok : T1 s) -> R1 s a
+data R1 : (rs : Resources) -> (a : Type) ->  Type where
+  (#) : (v : a) -> (1 tok : T1 rs) -> R1 rs a
+
+||| The result of allocating a linear resource
+public export
+data A1 : (rs : Resources) -> (a : Type) ->  Type where
+  A : (v : a) -> (1 tok : T1 (v::rs)) -> A1 rs a
 
 ||| `R1` is a functor, but since `map` does not have the correct
 ||| quantities, this is what we use instead.
 export
-mapR1 : (a -> b) -> (1 r : R1 s a) -> R1 s b
+mapR1 : (a -> b) -> (1 r : R1 rs a) -> R1 rs b
 mapR1 f (v # t) = f v # t
 
-||| A linear computation in state thread `s` that only updates
-||| the state without producing an interesting result.
+||| A computation mutating some state where resources a allocated or
+||| released.
 public export
-0 F1' : (s : Type) -> Type
-F1' s = T1 s -@ T1 s
+0 C1' : (rs,ss : Resources) -> Type
+C1' rs ss = T1 rs -@ T1 ss
 
-||| A linear computation in state thread `s` that produces a
+||| Convenience alias for `C1' rs rs`.
+public export
+0 F1' : (rs : Resources) -> Type
+F1' rs = C1' rs rs
+
+||| A linear computation operating on resources `rs` that produces a
 ||| result of type `a`.
 public export
-0 F1 : (s : Type) -> (a : Type) -> Type
-F1 s a = T1 s -@ R1 s a
+0 F1 : (rs : Resources) -> (a : Type) -> Type
+F1 rs a = T1 rs -@ R1 rs a
+
+export %inline
+ffi : ((1 p : AnyPtr) -> AnyPtr) -> F1' rs
+ffi f (T t) = T (f t)
 
 ||| Runs a linear computation by providing it with its own linear token.
 |||
@@ -76,32 +98,17 @@ F1 s a = T1 s -@ R1 s a
 ||| corresponding mutable state leaks into the outer world, because
 ||| the result value must have quantity omega (see the definition of `R1`).
 export %noinline
-run1 : (forall s . F1 s a) -> a
-run1 f = let v # t1 := f {s = ()} token in discard t1 v
-
-||| Sometimes, it is necessary to let callers decide, when they want to
-||| get rid of the linear token. This is, for instance, necessary when
-||| converting a mutable array to an immutable one.
-|||
-||| In order to do this safely, the mutable array needs to be copied, because
-||| it might still be updated later on. However, in many occasions this is
-||| inefficient, because the whole point of using a mutable array is to
-||| eventually convert it to an immutable one. Then the conversion
-||| can happen without copying, if and only if
-||| the linear token is destroyed at the same time which renders the mutable
-||| array (tagged to the now destroyed token) useless.
-export %noinline
-runUr : (forall s . (1 t : T1 s) -> Ur a) -> a
-runUr f = unrestricted (f {s = ()} token)
+run1 : F1 [] a -> a
+run1 f = let v # T _ := f (believe_me $ the Bits8 0) in v
 
 ||| Run the given stateful computation if the boolean value is `True`.
 export
-when1 : Bool -> Lazy (F1' s) -> F1' s
+when1 : Bool -> Lazy (F1' rs) -> F1' rs
 when1 True  f t = f t
 when1 False _ t = t
 
 ||| Run a stateful computation `n` times
 export
-forN : Nat -> F1' s -> F1' s
+forN : Nat -> F1' rs -> F1' rs
 forN 0     f t = t
 forN (S k) f t = forN k f (f t)

--- a/src/Data/Linear/Traverse1.idr
+++ b/src/Data/Linear/Traverse1.idr
@@ -221,10 +221,10 @@ Traversable1 List1 where
 -- Utilities
 --------------------------------------------------------------------------------
 
-pairIx : Ref1 () s Nat => a -> F1 s (Nat,a)
-pairIx v t = mapR1 (,v) (readAndMod1 S t)
+pairIx : (r : Ref1 Nat) -> a -> F1 [r] (Nat,a)
+pairIx r v t = mapR1 (,v) (readAndMod1 r S t)
 
 ||| Pairs each value in a data structure with its index of appearance.
 export %inline
 zipWithIndex : Traversable1 f => f a -> f (Nat,a)
-zipWithIndex as = withRef1 Z (traverse1 pairIx as)
+zipWithIndex as = withRef1 Z $ \r => (traverse1 (pairIx r) as)


### PR DESCRIPTION
This is a larger refactoring for experimenting with a new approach for several reasons:

1. Using auto-implicit resource did not improve the syntax the way I hoped (and it led to a lot of duplicated methods: tagged ones and untagged ones).
2. By binding a mutable resource to the linear token, we get safe resource management and avoid having to use `Ur`.
3. Since `run1` has now type `F1 [] a`, we are guaranteed all allocated resources have been released.