### PR TITLE
[ performance ] use World as linear token

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,18 +54,22 @@ tail-recursion in a much simpler way):
 
 ```idris
 nextFibo : (r1,r2 : Ref1 Nat) -> F1' [r1,r2]
-nextFibo r1 r2 t0 =
-  let f1 # t1 := read1 r1 t0
-      f2 # t2 := read1 r2 t1
-   in write1 r1 f2 (write1 r2 (f1+f2) t2)
+nextFibo r1 r2 t =
+  let f1 # t := read1 r1 t
+      f2 # t := read1 r2 t
+      _  # t := write1 r2 (f1+f2) t
+   in write1 r1 f2 t
 
 fibo : Nat -> Nat
 fibo n =
-  run1 $ \t0 =>
-    let A r2 t1 := ref1 (S Z) t0
-        A r1 t2 := ref1 (S Z) t1
-        v #  t3 := read1 r1 (forN n (nextFibo r1 r2) t2)
-     in v # (release r1 (release r2 t3))
+  run1 $ \t =>
+    let A r2 t := ref1 (S Z) t
+        A r1 t := ref1 (S Z) t
+        _ #  t := forN n (nextFibo r1 r2) t
+        v #  t := read1 r1 t
+        _ #  t := release r1 t
+        _ #  t := release r2 t
+     in v # t
 ```
 
 Or, with some syntactic sugar sprinkled on top:
@@ -580,9 +584,10 @@ zipping the values in a list with their index:
 
 ```idris
 pairWithIndex1 : (r : Ref1 Nat) -> a -> (1 t : T1 [r]) -> R1 [r] (Nat,a)
-pairWithIndex1 r v t1 =
-  let n # t2 := read1 r t1
-   in (n,v) # write1 r (S n) t2
+pairWithIndex1 r v t =
+  let n # t := read1 r t
+      _ # t := write1 r (S n) t
+   in (n,v) # t
 
 zipWithIndex1 : Traversable1 f => f a -> f (Nat,a)
 zipWithIndex1 as = withRef1 0 $ \r => traverse1 (pairWithIndex1 r) as
@@ -652,13 +657,20 @@ inc : (r : Ref1 Nat) -> (0 p : Res r rs) => F1' rs
 inc r = mod1 r S
 
 endWord : (b : Ref1 Bool) -> (w : Ref1 Nat) -> F1' [c,w,l,b]
-endWord b w t = write1 b False (whenRef1 b (inc w) t)
+endWord b w t =
+  let _ # t := whenRef1 b (inc w) t
+   in write1 b False t
 
 processChar : (c,w,l : Ref1 Nat) -> (b : Ref1 Bool) -> Char -> F1' [c,w,l,b]
 processChar c w l b x t =
   case isAlpha x of
-    True  => inc c (write1 b True t)
-    False => inc c $ endWord b w $ when1 (x == '\n') (inc l) t
+    True  =>
+      let _ # t := write1 b True t
+       in inc c t
+    False =>
+      let _ # t := when1 (x == '\n') (inc l) t
+          _ # t := endWord b w t
+       in inc c t
 ```
 
 The actual `wordCount` function has to setup all mutable variables,
@@ -682,12 +694,13 @@ wordCount s  =
         A l t  := ref1 (S Z) t
         A w t  := ref1 Z t
         A c t  := ref1 Z t
-        t      := traverse1_ (processChar c w l b) (unpack s) t
-        t      := endWord b w t
+        _ # t  := traverse1_ (processChar c w l b) (unpack s) t
+        _ # t  := endWord b w t
         x  # t := readAndRelease c t
         y  # t := readAndRelease w t
         z  # t := readAndRelease l t
-     in WC x y z # release b t
+        _  # t := release b t
+     in WC x y z # t
 ```
 
 This last step is quite verbose. This is to be expected: Just like in

--- a/profile/src/Main.idr
+++ b/profile/src/Main.idr
@@ -13,9 +13,9 @@ import Profile
 
 pairLet : (r : Ref1 Nat) -> a -> F1 [r] (Nat,a)
 pairLet r x t =
-  let n # t2 := read1 r t
-      t3     := write1 r (S n) t2
-   in (n,x) # t3
+  let n # t := read1 r t
+      _ # t := write1 r (S n) t
+   in (n,x) # t
 
 pairSugar : (r : Ref1 Nat) -> a -> F1 [r] (Nat,a)
 pairSugar r v = Syntax.do

--- a/ref1.ipkg
+++ b/ref1.ipkg
@@ -10,5 +10,6 @@ depends    = base         >= 0.7.0
 modules = Data.Linear.List
         , Data.Linear.Ref1
         , Data.Linear.Token
-        , Data.Linear.Token.Syntax
         , Data.Linear.Traverse1
+
+        , Syntax.T1

--- a/src/Data/Linear/Ref1.idr
+++ b/src/Data/Linear/Ref1.idr
@@ -20,9 +20,9 @@ export %foreign "scheme:(lambda (x) (unbox x))"
                 "javascript:lambda:(x) => x.value"
 prim__readRef  : Mut -> AnyPtr
 
-export %foreign "scheme:(lambda (x v t) (begin (set-box! x v) t))"
-                "javascript:lambda:(x,v,t) => {x.value = v; return t;}"
-prim__writeRef : Mut -> (val : AnyPtr) -> (1 x : AnyPtr) -> AnyPtr
+export %foreign "scheme:(lambda (x v) (set-box! x v))"
+                "javascript:lambda:(x,v,t) => {x.value = v}"
+prim__writeRef : Mut -> (val : AnyPtr) -> PrimIO ()
 
 --------------------------------------------------------------------------------
 -- Ref1: A linearily mutable reference
@@ -39,22 +39,22 @@ data Ref1 : (a : Type) -> Type where
 
 ||| Creates a new mutable reference tagged with `tag` and holding
 ||| initial value `v`.
-export %noinline
+export %inline
 ref1 : (v : a) -> (1 t : T1 rs) -> A1 rs (Ref1 a)
 ref1 v t = A (R1 $ prim__newRef $ believe_me v) (unsafeBind t)
 
 ||| Reads the current value at a mutable reference tagged with `tag`.
-export %noinline
+export %inline
 read1 : (r : Ref1 a) -> (0 p : Res r rs) => F1 rs a
 read1 (R1 m) t = believe_me (prim__readRef m) # t
 
 ||| Updates the mutable reference tagged with `tag`.
-export
+export %inline
 write1 : (r : Ref1 a) -> (0 p : Res r rs) => (val : a) -> F1' rs
 write1 (R1 m) val = ffi (prim__writeRef m (believe_me val))
 
 ||| Modifies the value stored in mutable reference tagged with `tag`.
-export
+export %inline
 mod1 : (r : Ref1 a) -> (0 p : Res r rs) => (f : a -> a) -> F1' rs
 mod1 r f t = let v # t2 := read1 r t in write1 r (f v) t2
 
@@ -62,13 +62,18 @@ mod1 r f t = let v # t2 := read1 r t in write1 r (f v) t2
 ||| and returns the updated value.
 export
 modAndRead1 : (r : Ref1 a) -> (0 p : Res r rs) => (f : a -> a) -> F1 rs a
-modAndRead1 r f t = read1 r (mod1 r f t)
+modAndRead1 r f t =
+  let _ # t := mod1 r f t
+   in read1 r t
 
 ||| Modifies the value stored in mutable reference tagged with `tag`
 ||| and returns the previous value.
 export
 readAndMod1 : (r : Ref1 a) -> (0 p : Res r rs) => (f : a -> a) -> F1 rs a
-readAndMod1 r f t = let v # t1 := read1 r t in v # write1 r (f v) t1
+readAndMod1 r f t =
+  let v # t := read1 r t
+      _ # t := write1 r (f v) t
+   in v # t
 
 ||| Runs the given stateful computation only when given boolean flag
 ||| is currently at `True`
@@ -91,7 +96,10 @@ readAndRelease :
      (r : Ref1 a)
   -> {auto 0 p : Res r rs}
   -> C1 rs (Drop rs p) a
-readAndRelease r t = let v # t2 := read1 r t in v # release r t2
+readAndRelease r t =
+  let v # t := read1 r t
+      _ # t := release r t
+   in v # t
 
 --------------------------------------------------------------------------------
 -- Allocating mutable references
@@ -110,4 +118,5 @@ withRef1 v f =
   run1 $ \t =>
     let A r t := ref1 v t
         v # t := f r t
-     in v # release r t
+        _ # t := release r t
+     in v # t

--- a/src/Data/Linear/Ref1.idr
+++ b/src/Data/Linear/Ref1.idr
@@ -76,7 +76,7 @@ whenRef1 r f t = let b # t1 := read1 r t in when1 b f t1
 ||| Releases a mutable reference.
 |||
 ||| It will no longer be accessible through the given linear token.
-export %noinline
+export %inline
 release : (r : Ref1 a) -> (0 p : Res r rs) => C1' rs (Drop rs p)
 release r t = unsafeRelease p t
 
@@ -84,10 +84,7 @@ release r t = unsafeRelease p t
 |||
 ||| It will no longer be accessible through the given linear token.
 export %inline
-readAndRelease :
-     (r : Ref1 a)
-  -> {auto 0 p : Res r rs}
-  -> C1 rs (Drop rs p) a
+readAndRelease : (r : Ref1 a) -> (0 p : Res r rs) => C1 rs (Drop rs p) a
 readAndRelease r t =
   let v # t := read1 r t
       _ # t := release r t

--- a/src/Data/Linear/Token.idr
+++ b/src/Data/Linear/Token.idr
@@ -165,12 +165,12 @@ unsafeRelease : (0 p : Res r rs) -> C1' rs (Drop rs p)
 unsafeRelease _ w = () # w
 
 ||| Use this to convert a primitive FFI call to a linear function
-||| of type `F1' rs`.
+||| of type `F1 rs a`.
 |||
 ||| This is typically used for running effectful computations that
 ||| do not produce an interesting result.
 ||| See `Data.Linear.Ref1.prim__writeRef` and
 ||| the corresponding `Data.Linear.Ref1.write1` for a usage example.
 export %inline
-ffi : PrimIO () -> F1' rs
-ffi prim w = let MkIORes _ w := prim w in () # w
+ffi : PrimIO a -> F1 rs a
+ffi prim w = let MkIORes v w := prim w in v # w

--- a/src/Data/Linear/Token.idr
+++ b/src/Data/Linear/Token.idr
@@ -135,7 +135,7 @@ forN (S k) f t =
 ||| that can then be accessed via the updated linear token.
 ||| See `Data.Linear.Ref1.prim__newRef` and the corresponding
 ||| `Data.Linear.Ref1.ref1` for a usage example.
-export
+export %inline
 unsafeBind : (1 t : T1 rs) -> T1 (r::rs)
 unsafeBind w = w
 

--- a/src/Data/Linear/Token/Syntax.idr
+++ b/src/Data/Linear/Token/Syntax.idr
@@ -15,7 +15,7 @@ export %inline
 
 export %inline
 (>>) : {0 rs,ss,ts : _} -> C1' rs ss -> C1 ss ts b -> C1 rs ts b
-(>>) f g t = let t2 := f t in g t2
+(>>) f g t = let _ # t := f t in g t
 
 export %inline
 (<*>) : {0 rs,ss,ts : _} -> C1 rs ss (a -> b) -> C1 ss ts a -> C1 rs ts b
@@ -51,12 +51,12 @@ data Allocs : (ts : List Type)  -> Type where
 ||| Allocates several resources and binds them to a linear token
 ||| in one go.
 export
-allocAll : All Alloc ts -> (1 t : T1 []) -> Allocs ts
+allocAll : All Alloc xs -> (1 t : T1 []) -> Allocs xs
 allocAll []      t = AS [] t
 allocAll (f::fs) t =
-  let AS vs t2 := allocAll fs t
-      A  v  t3 := f t2
-   in AS (v::vs) t3
+  let AS {ts} vs t := allocAll fs t
+      A  v       t := f {rs = RS vs} t
+   in AS (v::vs) t
 
 ||| Like `run1`, but for linear computations that work with several
 ||| bound resources at the same time.

--- a/src/Data/Linear/Traverse1.idr
+++ b/src/Data/Linear/Traverse1.idr
@@ -32,7 +32,7 @@ Foldable1 Maybe where
   foldMap1 f Nothing  t = neutral # t
   foldMap1 f (Just x) t = f x t
 
-  traverse1_ f Nothing  t = t
+  traverse1_ f Nothing  t = () # t
   traverse1_ f (Just v) t = f v t
 
 export
@@ -46,7 +46,7 @@ Foldable1 (Either e) where
   foldMap1 f (Left _)  t = neutral # t
   foldMap1 f (Right x) t = f x t
 
-  traverse1_ f (Left _)  t = t
+  traverse1_ f (Left _)  t = ()# t
   traverse1_ f (Right v) t = f v t
 
 -- List and SnocList
@@ -87,13 +87,13 @@ foldMap1SnocList f = go neutral
 
 export
 traverse1_List : (a -> F1' s) -> List a -> F1' s
-traverse1_List f []        t = t
-traverse1_List f (x :: xs) t = traverse1_List f xs (f x t)
+traverse1_List f []        t = () # t
+traverse1_List f (x :: xs) t = let _ # t := f x t in traverse1_List f xs t
 
 export
 traverse1_SnocList : (a -> F1' s) -> SnocList a -> F1' s
-traverse1_SnocList f [<]       t = t
-traverse1_SnocList f (sx :< x) t = traverse1_SnocList f sx (f x t)
+traverse1_SnocList f [<]       t = () # t
+traverse1_SnocList f (sx :< x) t = let _ # t := f x t in traverse1_SnocList f sx t
 
 export %inline
 Foldable1 List where
@@ -132,8 +132,8 @@ foldMap1Vect f = go neutral
 
 export
 traverse1_Vect : (a -> F1' s) -> Vect n a -> F1' s
-traverse1_Vect f []        t = t
-traverse1_Vect f (x :: xs) t = traverse1_Vect f xs (f x t)
+traverse1_Vect f []        t = () # t
+traverse1_Vect f (x :: xs) t = let _ # t := f x t in traverse1_Vect f xs t
 
 export %inline
 Foldable1 (Vect n) where

--- a/src/Syntax/T1.idr
+++ b/src/Syntax/T1.idr
@@ -1,4 +1,4 @@
-module Data.Linear.Token.Syntax
+module Syntax.T1
 
 import public Data.List.Quantifiers
 import public Data.Linear.Token

--- a/src/Syntax/T1.idr
+++ b/src/Syntax/T1.idr
@@ -9,16 +9,13 @@ export %inline
 pure : a -> F1 s a
 pure = (#)
 
-io_bind : {0 rs,ss,ts : _} -> C1 rs ss a -> (a -> C1 ss ts b) -> C1 rs ts b
-io_bind f g t1 = let v # t2 := f t1 in g v t2
-
 export %inline
 (>>=) : {0 rs,ss,ts : _} -> C1 rs ss a -> (a -> C1 ss ts b) -> C1 rs ts b
-(>>=) = io_bind
+(>>=) f g t1 = let v # t2 := f t1 in g v t2
 
 export %inline
 (>>) : {0 rs,ss,ts : _} -> C1' rs ss -> C1 ss ts b -> C1 rs ts b
-(>>) f g = io_bind f (\_ => g)
+(>>) f g = T1.(>>=) f (\_ => g)
 
 export %inline
 (<*>) : {0 rs,ss,ts : _} -> C1 rs ss (a -> b) -> C1 ss ts a -> C1 rs ts b

--- a/src/Syntax/T1.idr
+++ b/src/Syntax/T1.idr
@@ -9,20 +9,23 @@ export %inline
 pure : a -> F1 s a
 pure = (#)
 
+io_bind : {0 rs,ss,ts : _} -> C1 rs ss a -> (a -> C1 ss ts b) -> C1 rs ts b
+io_bind f g t1 = let v # t2 := f t1 in g v t2
+
 export %inline
 (>>=) : {0 rs,ss,ts : _} -> C1 rs ss a -> (a -> C1 ss ts b) -> C1 rs ts b
-(>>=) f g t1 = let v # t2 := f t1 in g v t2
+(>>=) = io_bind
 
 export %inline
 (>>) : {0 rs,ss,ts : _} -> C1' rs ss -> C1 ss ts b -> C1 rs ts b
-(>>) f g t = let _ # t := f t in g t
+(>>) f g = io_bind f (\_ => g)
 
 export %inline
 (<*>) : {0 rs,ss,ts : _} -> C1 rs ss (a -> b) -> C1 ss ts a -> C1 rs ts b
-(<*>) f g t =
-  let fn # t2 := f t
-      v  # t3 := g t2
-   in fn v # t3
+(<*>) f g = T1.do
+  fn <- f
+  v  <- g
+  pure (fn v)
 
 --------------------------------------------------------------------------------
 -- Allocating many resources


### PR DESCRIPTION
This improves performance, because the compiler can optimize the world token away. Thus, the linear pair types introduced in this library are actually converted to newtype wrappers (just like `IORes`).