### PR TITLE
[ refactor ] ditch resource management

### DIFF
--- a/src/Data/Linear/Ref1.idr
+++ b/src/Data/Linear/Ref1.idr
@@ -27,21 +27,13 @@ prim__casWrite : Mut a -> (prev,val : a) -> Bits8
 
 ||| A linear mutable reference
 export
-data Ref : RTag -> (a : Type) -> Type where
-  R1 : (mut : Mut a) -> Ref t a
-
-||| Alias for `Ref RPure`
-public export
-0 Ref1 : Type -> Type
-Ref1 = Ref RPure
+data Ref : (s,a : Type) -> Type where
+  R1 : (mut : Mut a) -> Ref s a
 
 ||| Alias for `Ref RIO`
 public export
 0 IORef : Type -> Type
-IORef = Ref RIO
-
-public export
-InIO (Ref RIO a) where
+IORef = Ref World
 
 --------------------------------------------------------------------------------
 -- utilities
@@ -50,23 +42,17 @@ InIO (Ref RIO a) where
 ||| Creates a new mutable reference tagged with `tag` and holding
 ||| initial value `v`.
 export %inline
-ref1 : (v : a) -> (1 t : T1 rs) -> A1 rs (Ref1 a)
-ref1 v t = let m # t := ffi (prim__newIORef v) t in R1 m # unsafeBind t
-
-||| Creates a mutable reference in `IO` land.
-export %inline
-refIO : (v : a) -> F1 [World] (IORef a)
-refIO v t = let m # t := ffi (prim__newIORef v) t in R1 m # t
+ref : (v : a) -> F1 s (Ref s a)
+ref v t = let m # t := ffi (prim__newIORef v) t in R1 m # t
 
 ||| Creates a mutable reference in `IO` land.
 export %inline
 newIORef : HasIO io => (v : a) -> io (IORef a)
-newIORef v =
-  primIO $ \w => let MkIORes m w := prim__newIORef v w in MkIORes (R1 m) w
+newIORef v = runIO (ref v)
 
 ||| Reads the current value at a mutable reference tagged with `tag`.
 export %inline
-read1 : (r : Ref t a) -> (0 p : Res r rs) => F1 rs a
+read1 : (r : Ref s a) -> F1 s a
 read1 (R1 m) = ffi (prim__readIORef m)
 
 ||| Convenience alias for `runIO $ read1 r` for reading a reference in
@@ -77,7 +63,7 @@ readref r = runIO $ read1 r
 
 ||| Updates the mutable reference tagged with `tag`.
 export %inline
-write1 : (r : Ref t a) -> (0 p : Res r rs) => (val : a) -> F1' rs
+write1 : (r : Ref s a) -> (val : a) -> F1' s
 write1 (R1 m) val = ffi (prim__writeIORef m val)
 
 ||| Convenience alias for `runIO $ write1 r v` for writing to a reference in
@@ -93,7 +79,7 @@ writeref r v = runIO $ write1 r v
 ||| It trivially works on the JavaScript backends, which are single-threaded
 ||| anyway.
 export %inline
-caswrite1 : (r : Ref t a) -> (0 p : Res r rs) => (pre,val : a) -> F1 rs Bool
+caswrite1 : (r : Ref s a) -> (pre,val : a) -> F1 s Bool
 caswrite1 (R1 m) pre val t =
   case prim__casWrite m pre val of
     0 => False # t
@@ -106,10 +92,10 @@ caswrite1 (R1 m) pre val t =
 ||| It trivially works on the JavaScript backends, which are single-threaded
 ||| anyway.
 export
-casupdate1 : (r : Ref t a) -> (a -> (a,b)) -> (0 p : Res r rs) => F1 rs b
+casupdate1 : (r : Ref s a) -> (a -> (a,b)) -> F1 s b
 casupdate1 r f t = assert_total (loop t)
   where
-    covering loop : F1 rs b
+    covering loop : F1 s b
     loop t =
       let cur # t  := read1 r t
           (new,v)  := f cur
@@ -130,10 +116,10 @@ update r v = runIO $ casupdate1 r v
 ||| It trivially works on the JavaScript backends, which are single-threaded
 ||| anyway.
 export
-casmod1 : (r : Ref t a) -> (a -> a) -> (0 p : Res r rs) => F1' rs
+casmod1 : (r : Ref s a) -> (a -> a) -> F1' s
 casmod1 r f t = assert_total (loop t)
   where
-    covering loop : F1' rs
+    covering loop : F1' s
     loop t =
       let cur  # t := read1 r t
           True # t := caswrite1 r cur (f cur) t | _ # t => loop t
@@ -141,7 +127,7 @@ casmod1 r f t = assert_total (loop t)
 
 ||| Modifies the value stored in mutable reference tagged with `tag`.
 export %inline
-mod1 : (r : Ref t a) -> (0 p : Res r rs) => (f : a -> a) -> F1' rs
+mod1 : (r : Ref s a) -> (f : a -> a) -> F1' s
 mod1 r f t = let v # t2 := read1 r t in write1 r (f v) t2
 
 ||| Atomically modifies a mutable reference in `IO`.
@@ -154,7 +140,7 @@ mod r f = runIO $ casmod1 r f
 ||| Modifies the value stored in mutable reference tagged with `tag`
 ||| and returns the updated value.
 export
-modAndRead1 : (r : Ref t a) -> (0 p : Res r rs) => (f : a -> a) -> F1 rs a
+modAndRead1 : (r : Ref s a) -> (f : a -> a) -> F1 s a
 modAndRead1 r f t =
   let _ # t := mod1 r f t
    in read1 r t
@@ -162,7 +148,7 @@ modAndRead1 r f t =
 ||| Modifies the value stored in mutable reference tagged with `tag`
 ||| and returns the previous value.
 export
-readAndMod1 : (r : Ref t a) -> (0 p : Res r rs) => (f : a -> a) -> F1 rs a
+readAndMod1 : (r : Ref s a) -> (f : a -> a) -> F1 s a
 readAndMod1 r f t =
   let v # t := read1 r t
       _ # t := write1 r (f v) t
@@ -171,25 +157,8 @@ readAndMod1 r f t =
 ||| Runs the given stateful computation only when given boolean flag
 ||| is currently at `True`
 export
-whenRef1 : (r : Ref t Bool) -> (0 p : Res r rs) => Lazy (F1' rs) -> F1' rs
+whenRef1 : (r : Ref s Bool) -> Lazy (F1' s) -> F1' s
 whenRef1 r f t = let b # t1 := read1 r t in when1 b f t1
-
-||| Releases a mutable reference.
-|||
-||| It will no longer be accessible through the given linear token.
-export %inline
-release : (r : Ref1 a) -> (0 p : Res r rs) => C1' rs (Drop rs p)
-release r t = unsafeRelease p t
-
-||| Read and releases a mutable reference.
-|||
-||| It will no longer be accessible through the given linear token.
-export %inline
-readAndRelease : (r : Ref1 a) -> (0 p : Res r rs) => C1 rs (Drop rs p) a
-readAndRelease r t =
-  let v # t := read1 r t
-      _ # t := release r t
-   in v # t
 
 --------------------------------------------------------------------------------
 -- Allocating mutable references
@@ -199,14 +168,9 @@ readAndRelease r t =
 ||| an auto-implicit argument.
 public export
 0 WithRef1 : (a,b : Type) -> Type
-WithRef1 a b = (r : Ref1 a) -> F1 [r] b
+WithRef1 a b = forall s . (r : Ref s a) -> F1 s b
 
 ||| Runs a function requiring a linear mutable reference.
 export
 withRef1 : a -> WithRef1 a b -> b
-withRef1 v f =
-  run1 $ \t =>
-    let r # t := ref1 v t
-        v # t := f r t
-        _ # t := release r t
-     in v # t
+withRef1 v f = run1 $ \t => let r # t := ref v t in f r t

--- a/src/Data/Linear/Token.idr
+++ b/src/Data/Linear/Token.idr
@@ -4,63 +4,9 @@ import public Data.Linear
 
 %default total
 
---------------------------------------------------------------------------------
--- Resources
---------------------------------------------------------------------------------
-
-||| A tag for marking resources that can be used both in `IO` or in pure
-||| computations.
-public export
-data RTag = RPure | RIO
-
-||| A tag for linear computation that should be run in `IO`
+||| An empty type for tagging linear computations that can be wrapped in `IO`
 public export
 data World : Type where
-
-||| Interface for tagging types that should be evaluated in
-||| `IO` land.
-public export
-interface InIO a where
-
-||| A list of arbitrary managed resources.
-|||
-||| This is used as parameter for the linear token `T1`
-||| provided by this library. The idea is that only resources
-||| bound to the linear token can be used in the current linear
-||| context.
-|||
-||| We distinguish between two cases: Values that belong to `IO` land
-||| (i.e. mutable references and arrays coming from and being sent
-||| to the FFI), and values that should be created (and, possibly, release)
-||| in pure computations.
-|||
-||| For the former types of values, `Resources` should be equal to `[World]`,
-||| and the corresponding types should implement interface `InIO`. These
-||| values can be freely used in linear computations involving a linear
-||| token of type `T1 [World] a`, but running these computations is an `IO`
-||| action.
-|||
-||| For the latter type of values (those being used in pure computations),
-||| `T1 rs a` should be used, where `rs` is a list of linear resources bound
-||| to the linear token.
-public export
-data Resources : Type where
-  Nil  : Resources
-  (::) : {0 t : Type} -> (v : t) -> Resources -> Resources
-
-||| Proof that resource `r` is in the list of resources `rs`.
-public export
-data Res : (r : t) -> (rs : Resources) -> Type where
-  RH : Res r (r::rs)
-  RT : Res r rs -> Res r (s::rs)
-  RW : {0 t : Type} -> {0 r : t} -> InIO t => Res r [World]
-
-||| Removes resource `r` from the list of managed resources `rs`.
-public export
-0 Drop : (rs : Resources) -> Res r rs -> Resources
-Drop (r :: rs) RH     = rs
-Drop (s :: rs) (RT x) = s :: Drop rs x
-Drop [World]   RW     = [World]
 
 --------------------------------------------------------------------------------
 -- T1
@@ -74,57 +20,38 @@ Drop [World]   RW     = [World]
 |||
 ||| The advantage of using linear types over the `ST` monad: They come
 ||| without the (significant) performance overhead of monadic code in
-||| Idris. In addition, this provides safe resource handling, because
+||| Idris. Like the `ST` monad, this provides safe resource handling, because
 ||| the function for running linear computations over a `T1` (function
-||| `run1` must work with function argument `f` of type
-||| `(1 t : T1 []) -> R1 [] a`, that is, any resources required must
-||| be allocated and released within `f`.
+||| `run1`) must work with function argument `f` of type
+||| `forall s . (1 t : T1 s) -> R1 s a`, that is, mutable references cannot
+||| leak out of the linear computation and remain usable.
 export %noinline %tcinline
-0 T1 : (rs : Resources) -> Type
-T1 rs = %World
+0 T1 : (s : Type) -> Type
+T1 s = %World
 
 ||| The result of a stateful linear computation.
 |||
 ||| It pairs the result value with a new linear token.
 public export
-data Res1 : (a : Type) -> (f : a -> Resources) ->  Type where
-  (#) : (v : a) -> (1 tok : T1 (f v)) -> Res1 a f
-
-public export
-0 R1 : Resources -> Type -> Type
-R1 rs a = Res1 a (const rs)
-
-public export
-0 A1 : Resources -> Type -> Type
-A1 rs a = Res1 a (::rs)
+data R1 : (s,a : Type) ->  Type where
+  (#) : (v : a) -> (1 tok : T1 s) -> R1 s a
 
 ||| `R1` is a functor, but since `map` does not have the correct
 ||| quantities, this is what we use instead.
 export
-mapR1 : (a -> b) -> (1 r : R1 rs a) -> R1 rs b
+mapR1 : (a -> b) -> (1 r : R1 s a) -> R1 s b
 mapR1 f (v # t) = f v # t
-
-||| A computation mutating some state where resources a allocated or
-||| released.
-public export
-0 C1' : (rs,ss : Resources) -> Type
-C1' rs ss = T1 rs -@ R1 ss ()
-
-||| Convenience alias for `C1' rs rs`.
-public export
-0 F1' : (rs : Resources) -> Type
-F1' rs = C1' rs rs
 
 ||| A linear computation operating on resources `rs` that produces a
 ||| result of type `a` with a new token operating on resources `ss`.
 public export
-0 C1 : (rs,ss : Resources) -> (a : Type) -> Type
-C1 rs ss a = T1 rs -@ R1 ss a
+0 F1 : (s : Type) -> (a : Type) -> Type
+F1 s a = (1 t : T1 s) -> R1 s a
 
-||| Convenience alias for `C1 rs rs`
+||| Convenience alias for `F1 s ()`.
 public export
-0 F1 : (rs : Resources) -> (a : Type) -> Type
-F1 rs = C1 rs rs
+0 F1' : (s : Type) -> Type
+F1' s = F1 s ()
 
 ||| Runs a linear computation by providing it with its own linear token.
 |||
@@ -136,39 +63,39 @@ F1 rs = C1 rs rs
 ||| corresponding mutable state leaks into the outer world, because
 ||| the result value must have quantity omega (see the definition of `R1`).
 export %noinline
-run1 : F1 [] a -> a
-run1 f = let v # _ := f %MkWorld in v
+run1 : (forall s . F1 s a) -> a
+run1 f = let v # _ := f {s = ()} %MkWorld in v
 
 ||| Runs a linear computation tagged with `[World]` as a primitive
 ||| `IO` action.
 export %inline
-primRun : F1 [World] a -> PrimIO a
+primRun : F1 World a -> PrimIO a
 primRun f w = let v # w := f w in MkIORes v w
 
 ||| Convenience wrapper around `primRun`.
 export %inline
-runIO : HasIO io => F1 [World] a -> io a
+runIO : HasIO io => F1 World a -> io a
 runIO f = primIO $ primRun f
 
 ||| Safely uses a primitive `IO` action in `F1 [World]`.
 export %inline
-toF1 : PrimIO a -> F1 [World] a
+toF1 : PrimIO a -> F1 World a
 toF1 f w = let MkIORes v w := f w in v # w
 
 ||| Safely uses an `IO` action in `F1 [World]`.
 export %inline
-ioToF1 : IO a -> F1 [World] a
+ioToF1 : IO a -> F1 World a
 ioToF1 io = toF1 (toPrim io)
 
 ||| Run the given stateful computation if the boolean value is `True`.
 export
-when1 : Bool -> Lazy (F1' rs) -> F1' rs
+when1 : Bool -> Lazy (F1' s) -> F1' s
 when1 True  f t = f t
 when1 False _ t = () # t
 
 ||| Run a stateful computation `n` times
 export
-forN : Nat -> F1' rs -> F1' rs
+forN : Nat -> F1' s -> F1' s
 forN 0     f t = () # t
 forN (S k) f t =
   let _ # t := f t
@@ -178,47 +105,6 @@ forN (S k) f t =
 -- FFI
 --------------------------------------------------------------------------------
 
-||| Bind a new resource to the current linear token.
-|||
-||| This is for library authors when writing FFI bindings.
-||| Do not use it unless you know what you are doing! Never use this to
-||| bind an existing resource to a different linear token as this will
-||| make it possible to reuse a mutable reference in a different
-||| linear context, thus breaking referential transparency.
-|||
-||| Library authors should use this for allocating new resources
-||| that can then be accessed via the updated linear token.
-||| See `Data.Linear.Ref1.prim__newRef` and the corresponding
-||| `Data.Linear.Ref1.ref1` for a usage example.
-export %inline
-unsafeBind : (1 t : T1 rs) -> T1 (r::rs)
-unsafeBind w = w
-
-||| Release a resource from the token it was bound to.
-|||
-||| This is for library authors when writing FFI bindings.
-||| Do not use it unless you know what you are doing! Never use this to
-||| release a resource without actually doing the releasing too (such as
-||| freeing the memory allocated for a pointer)!
-|||
-||| Library authors should use this to remove a resource from the
-||| list of resources managed by a linear token. This should happen
-||| at the same time when the resource is actually released by an
-||| FFI call if necessary.
-||| See `Data.Linear.Ref1.release` for a basic usage example that does
-||| not actually release anything since our mutable references are garbage
-||| collected.
-|||
-||| A better usage example can be found in the idris2-array library,
-||| where function `freeze` removes an array from the list of
-||| managed resources and wraps it in an immutable array at the same
-||| time. Since the mutable array can no longer be accessed with the
-||| new linear token, it is safe to do this without copying the
-||| mutable array!
-export %inline
-unsafeRelease : (0 p : Res r rs) -> C1' rs (Drop rs p)
-unsafeRelease _ w = () # w
-
 ||| Use this to convert a primitive FFI call to a linear function
 ||| of type `F1 rs a`.
 |||
@@ -227,5 +113,5 @@ unsafeRelease _ w = () # w
 ||| See `Data.Linear.Ref1.prim__writeRef` and
 ||| the corresponding `Data.Linear.Ref1.write1` for a usage example.
 export %inline
-ffi : PrimIO a -> F1 rs a
+ffi : PrimIO a -> F1 s a
 ffi prim w = let MkIORes v w := prim w in v # w

--- a/src/Data/Linear/Traverse1.idr
+++ b/src/Data/Linear/Traverse1.idr
@@ -221,7 +221,7 @@ Traversable1 List1 where
 -- Utilities
 --------------------------------------------------------------------------------
 
-pairIx : (r : Ref1 Nat) -> a -> F1 [r] (Nat,a)
+pairIx : (r : Ref s Nat) -> a -> F1 s (Nat,a)
 pairIx r v t = mapR1 (,v) (readAndMod1 r S t)
 
 ||| Pairs each value in a data structure with its index of appearance.

--- a/src/Syntax/T1.idr
+++ b/src/Syntax/T1.idr
@@ -10,67 +10,16 @@ pure : a -> F1 s a
 pure = (#)
 
 export %inline
-(>>=) :
-     (T1 rs -@ Res1 a f)
-  -> ((v : a) -> T1 (f v) -@ Res1 b g)
-  -> T1 rs
-  -@ Res1 b g
+(>>=) : F1 s a -> (a -> F1 s b) -> F1 s b
 (>>=) f g t1 = let v # t2 := f t1 in g v t2
 
 export %inline
-(>>) :
-     (T1 rs -@ Res1 () f)
-  -> (T1 (f ()) -@ Res1 b g)
-  -> T1 rs
-  -@ Res1 b g
+(>>) : F1' s -> F1 s b -> F1 s b
 (>>) f g = T1.(>>=) f (\(),t => g t)
 
 export %inline
-(<*>) : {0 rs,ss,ts : _} -> C1 rs ss (a -> b) -> C1 ss ts a -> C1 rs ts b
+(<*>) : F1 s (a -> b) -> F1 s a -> F1 s b
 (<*>) f g = T1.do
   fn <- f
   v  <- g
   pure (fn v)
-
---------------------------------------------------------------------------------
--- Allocating many resources
---------------------------------------------------------------------------------
-
-||| Type alias for an allocator for resources of type `a`.
-public export
-0 Alloc : Type -> Type
-Alloc a = {0 rs : Resources} -> (1 t : T1 rs) -> A1 rs a
-
-||| Computes the resources corresponding to a heterogeneous list
-||| of values.
-public export
-0 RS : HList ts -> Resources
-RS []     = []
-RS (h::t) = h :: RS t
-
-||| Result of allocating many resources in one go.
-|||
-||| This pairs as heterogeneous list of resources of types `ts`
-||| with a linear token parameterized by those resources.
-public export
-0 Allocs : (ts : List Type) -> Type
-Allocs ts = Res1 (HList ts) RS
-
-||| Allocates several resources and binds them to a linear token
-||| in one go.
-export
-allocAll : All Alloc xs -> (1 t : T1 []) -> Allocs xs
-allocAll []      t = [] # t
-allocAll (f::fs) t =
-  let vs # t := allocAll fs t
-      v  # t := f {rs = RS vs} t
-   in (v::vs) # t
-
-||| Like `run1`, but for linear computations that work with several
-||| bound resources at the same time.
-export
-allocRun1 :
-     All Alloc ts
-  -> ((vs : HList ts) -> (1 t : T1 (RS vs)) -> R1 [] a)
-  -> a
-allocRun1 as f = run1 $ \t => let vs # t := allocAll as t in f vs t

--- a/test/src/Concurrent.idr
+++ b/test/src/Concurrent.idr
@@ -13,10 +13,10 @@ ITER = 1_000_000
 
 data Prog = Unsafe | CAS | Mut
 
-inc : (r : IORef Nat) -> F1' [World]
+inc : (r : Ref s Nat) -> F1' s
 inc r = mod1 r S
 
-casinc : (r : IORef Nat) -> F1' [World]
+casinc : (r : Ref s Nat) -> F1' s
 casinc r = casmod1 r S
 
 mutinc : Mutex -> IORef Nat -> Nat -> IO ()

--- a/test/src/ConcurrentQueue.idr
+++ b/test/src/ConcurrentQueue.idr
@@ -1,63 +1,63 @@
-module ConcurrentQueue
-
-import Data.Queue
-import Data.Vect as V
-import Data.Linear.Ref1
-import System.Concurrency
-import System
-
-%default total
-
-record State where
-  constructor ST
-  cur   : Nat
-  queue : Queue Nat
-
-next : State -> State
-next (ST n q) = ST (S n) (enqueue q n)
-
-ITER : Nat
-ITER = 10_000
-
-DELAY : Nat
-DELAY = 100_000
-
-data Prog = Unsafe | CAS | Mut
-
-inc : (r : Ref s State) -> Nat -> F1' s
-inc r 0     = mod1 r next
-inc r (S k) = inc r k
-
-casinc : (r : Ref s State) -> Nat -> F1' s
-casinc r 0     = casmod1 r next
-casinc r (S k) = casinc r k
-
-mutinc : Mutex -> IORef State -> Nat -> Nat -> IO ()
-mutinc m r n     (S k) = mutinc m r n k
-mutinc m r 0     0     = pure ()
-mutinc m r (S k) 0     = do
-  mutexAcquire m
-  runIO (inc r 0)
-  mutexRelease m
-  mutinc m r k DELAY
-
-prog : Prog -> Mutex -> IORef State -> IO ()
-prog Unsafe m ref = runIO (forN ITER $ inc ref DELAY)
-prog CAS    m ref = runIO (forN ITER $ casinc ref DELAY)
-prog Mut    m ref = mutinc m ref ITER DELAY
-
-runProg : Prog -> Nat -> IO (List Nat)
-runProg prg n = do
-  mut <- makeMutex
-  ref <- newIORef (ST 0 empty)
-  ts  <- sequence $ V.replicate n (fork $ prog prg mut ref)
-  traverse_ (\t => threadWait t) ts
-  toList . queue <$> runIO (read1 ref)
-
-main : IO ()
-main = do
-  us <- runProg Unsafe 4
-  cs <- runProg CAS 4
-  when (length us >= length cs) (die "no race condition")
-  when (cs /= [0 .. pred (4 * ITER)]) (die "CAS synchronization failed")
-  putStrLn "Concurrent queue succeeded!"
+-- module ConcurrentQueue
+--
+-- import Data.Queue
+-- import Data.Vect as V
+-- import Data.Linear.Ref1
+-- import System.Concurrency
+-- import System
+--
+-- %default total
+--
+-- record State where
+--   constructor ST
+--   cur   : Nat
+--   queue : Queue Nat
+--
+-- next : State -> State
+-- next (ST n q) = ST (S n) (enqueue q n)
+--
+-- ITER : Nat
+-- ITER = 10_000
+--
+-- DELAY : Nat
+-- DELAY = 100_000
+--
+-- data Prog = Unsafe | CAS | Mut
+--
+-- inc : (r : Ref s State) -> Nat -> F1' s
+-- inc r 0     = mod1 r next
+-- inc r (S k) = inc r k
+--
+-- casinc : (r : Ref s State) -> Nat -> F1' s
+-- casinc r 0     = casmod1 r next
+-- casinc r (S k) = casinc r k
+--
+-- mutinc : Mutex -> IORef State -> Nat -> Nat -> IO ()
+-- mutinc m r n     (S k) = mutinc m r n k
+-- mutinc m r 0     0     = pure ()
+-- mutinc m r (S k) 0     = do
+--   mutexAcquire m
+--   runIO (inc r 0)
+--   mutexRelease m
+--   mutinc m r k DELAY
+--
+-- prog : Prog -> Mutex -> IORef State -> IO ()
+-- prog Unsafe m ref = runIO (forN ITER $ inc ref DELAY)
+-- prog CAS    m ref = runIO (forN ITER $ casinc ref DELAY)
+-- prog Mut    m ref = mutinc m ref ITER DELAY
+--
+-- runProg : Prog -> Nat -> IO (List Nat)
+-- runProg prg n = do
+--   mut <- makeMutex
+--   ref <- newIORef (ST 0 empty)
+--   ts  <- sequence $ V.replicate n (fork $ prog prg mut ref)
+--   traverse_ (\t => threadWait t) ts
+--   toList . queue <$> runIO (read1 ref)
+--
+-- main : IO ()
+-- main = do
+--   us <- runProg Unsafe 4
+--   cs <- runProg CAS 4
+--   when (length us >= length cs) (die "no race condition")
+--   when (cs /= [0 .. pred (4 * ITER)]) (die "CAS synchronization failed")
+--   putStrLn "Concurrent queue succeeded!"

--- a/test/src/ConcurrentQueue.idr
+++ b/test/src/ConcurrentQueue.idr
@@ -24,11 +24,11 @@ DELAY = 100_000
 
 data Prog = Unsafe | CAS | Mut
 
-inc : (r : IORef State) -> Nat -> F1' [World]
+inc : (r : Ref s State) -> Nat -> F1' s
 inc r 0     = mod1 r next
 inc r (S k) = inc r k
 
-casinc : (r : IORef State) -> Nat -> F1' [World]
+casinc : (r : Ref s State) -> Nat -> F1' s
 casinc r 0     = casmod1 r next
 casinc r (S k) = casinc r k
 

--- a/test/src/Main.idr
+++ b/test/src/Main.idr
@@ -36,11 +36,7 @@ prop_readandmod1 =
     [x,y] <- forAll $ hlist [anyBits8, anyBits8]
     x === withRef1 x (\r => readAndMod1 r (+y))
 
-casWriteGet :
-     (r : Ref t a)
-  -> (pre,new : a)
-  -> {auto 0 p : Res r rs}
-  -> F1 rs (Bool,a)
+casWriteGet : (r : Ref s a) -> (pre,new : a) -> F1 s (Bool,a)
 casWriteGet r pre new t =
   let b # t := caswrite1 r pre new t
       v # t := read1 r t

--- a/test/test.ipkg
+++ b/test/test.ipkg
@@ -3,7 +3,6 @@ version = 0.1.0
 authors = "stefan-hoeck"
 
 depends = base >= 0.7.0
-        , containers
         , ref1
         , hedgehog
 


### PR DESCRIPTION
With this PR, I'm going to ditch safe resource handling in linear computations. This is going to break a lot of my own code, so I will thoroughly test its usability before merging.

Some background: It was always a bit cumbersome to unify pure linear computations and stateful computations that run in `IO`. With this PR, where the list of resources in `F1 rs a` is replaced with a simple type tag (`F1 s a`, just like in `ST s`), all linear computations can be reused in `IO` by replacing `s` with `World`. Since in a pure linear computation `s` must be universally quantified (just like in `ST s`), writing algorithms that can be used in pure as well as `IO` code is trivial.

About resource management: While a nice idea to experiment with, it does not compose well. It does not allow us to reuse linear computations that allocate resources along the way (for instance, by copying mutable arrays) in `IO`, which is already quite limiting. In addition, safe resource management does not compose well with higher abstractions such `Async` (from idris2-async) or the streaming library I'm currently experimenting with. In both cases, I have not yet figured out how to do resource management at the type level in the presence of error handling, cancelation, or asynchronous computations.

To make a long story short: With this PR, the API of this library is simplified and allows for better code reuse, while sacrificing resource safety in those cases where it would have been convenient to have (for instance, when allocating C pointers).