### PR TITLE
[ new ] atomically

### DIFF
--- a/test/src/Atomically.idr
+++ b/test/src/Atomically.idr
@@ -1,0 +1,50 @@
+module Atomically
+
+import Data.Vect as V
+import Data.Linear.Ref1
+import System.Concurrency
+import System
+
+%default total
+
+public export
+ITER : Nat
+ITER = 1_000_000
+
+data Prog = Unsafe | CAS | Mut
+
+inc : (r : Ref s Nat) -> F1' s
+inc r = mod1 r S
+
+casinc : (r : Ref s Nat) -> F1' s
+casinc r = casmod1 r S
+
+atomicallyinc : Mutex -> IORef Nat -> Nat -> IO ()
+atomicallyinc m r 0     = pure ()
+atomicallyinc m r (S k) = do
+  () <- runIO $ \t =>
+    atomically r m S t
+  atomicallyinc m r k
+
+prog : Prog -> Mutex -> IORef Nat -> IO ()
+prog Unsafe m ref = runIO (forN ITER $ inc ref)
+prog CAS    m ref = runIO (forN ITER $ casinc ref)
+prog Mut    m ref = atomicallyinc m ref ITER
+
+runProg : Prog -> Nat -> IO Nat
+runProg prg n = do
+  mut <- makeMutex
+  ref <- newref Z
+  ts  <- sequence $ V.replicate n (fork $ prog prg mut ref)
+  traverse_ (\t => threadWait t) ts
+  runIO (read1 ref)
+
+main : IO ()
+main = do
+  u <- runProg Unsafe 4
+  c <- runProg CAS 4
+  m <- runProg Mut 4
+  when (u >= c) (die "no race condition")
+  when (c /= 4 * ITER) (die "CAS synchronization failed")
+  when (m /= 4 * ITER) (die "atomically failed")
+  putStrLn "Atomically counter succeeded!"


### PR DESCRIPTION
This PR adds the function `atomically`:

```
export
atomically : (r : Ref World a) -> Mutex -> (f : a -> a) -> F1' World
atomically r lock f t =
  let _ # t := ioToF1 (mutexAcquire lock) t
      _ # t := casmod1 r f t
    in ioToF1 (mutexRelease lock) t
```

The `atomically` function runs its argument according to the provided `Mutex`.  It can for instance be used to modify the contents of a mutable reference `r` with a function `f` in a safe way in a multithreaded program provided that other threads also rely on the same `lock` to modify `r`.

A test suite was also added, `Atomically.idr`.